### PR TITLE
pass the event to the click handler

### DIFF
--- a/client_code/_Components/Link/__init__.py
+++ b/client_code/_Components/Link/__init__.py
@@ -31,7 +31,7 @@ class Link(LinkTemplate):
     
   def _handle_click(self, event):
     keys = {'shift': event.shiftKey, 'alt': event.altKey, 'ctrl': event.ctrlKey, 'meta': event.metaKey}
-    self.raise_event("click", keys=keys)
+    self.raise_event("click", keys=keys, event=event)
 
   def _anvil_get_interactions_(self):
     return [{

--- a/client_code/_Components/NavigationLink/__init__.py
+++ b/client_code/_Components/NavigationLink/__init__.py
@@ -28,7 +28,7 @@ class NavigationLink(NavigationLinkTemplate):
       anvil.designer.register_interaction(self, self.dom_nodes['anvil-m3-navigation-link'], 'dblclick', lambda x: anvil.designer.start_editing_form(self.navigate_to))
 
   def _handle_click(self, event):
-    self.raise_event("click")
+    self.raise_event("click", event=event)
     if self.navigate_to:
       open_form(self.navigate_to)
       self.selected = True


### PR DESCRIPTION
for routing - to use the m3 default links, the routing library will need the original event
