### PR TITLE
Fix flash of unstyled text (FOUT)

### DIFF
--- a/anvil.yaml
+++ b/anvil.yaml
@@ -7,8 +7,8 @@ native_deps:
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
-    <!-- <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"> -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" />
+    <!-- <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block" rel="stylesheet"> -->
     <script src="_/theme/anvil-m3/floating-ui/core@1.6.7.js"></script>
     <script src="_/theme/anvil-m3/floating-ui/dom@1.6.10.js"></script>
 package_name: m3


### PR DESCRIPTION
using &display=block causes the text to be hidden for a short period of time while the font loads

If the connection is slow there may still be a FOUT but this change is probably enough for the majority of use cases

We can explore more advanced options if we still think it's a problem

close #162 

for more info on font-display see: https://css-tricks.com/almanac/properties/f/font-display/