### PR TITLE
Add close button to Notifications and Confirms

### DIFF
--- a/theme/assets/theme.css
+++ b/theme/assets/theme.css
@@ -546,6 +546,9 @@ body {
   /* content: "\e5cd" */
 }
 
+.anvil-modal-header .anvil-close {
+  color: %color:On Surface%;
+}
 
 .anvil-modal-title {
   font-size: 24px;


### PR DESCRIPTION
All Notifications now have a close button that dismisses the alert Confirm modals also have one if `dismissible=True`. Previously, if you had a Notification with `timeout=None`, then there would be no way to get rid of the Notification