### PR TITLE
Dropdown border is not rounded on the dropdown menu

### DIFF
--- a/theme/assets/anvil-m3/menu.css
+++ b/theme/assets/anvil-m3/menu.css
@@ -87,7 +87,7 @@
   cursor: pointer;
 }
 
-.anvil-m3-menuItem-container:hover .anvil-m3-menuItem-core,  .anvil-m3-menuItem-container-keyboardHover .anvil-m3-menuItem-core,{
+.anvil-m3-menuItem-container:hover .anvil-m3-menuItem-core,  .anvil-m3-menuItem-container-keyboardHover .anvil-m3-menuItem-core {
   color: var(--anvil-m3-on-surface)
 }
 


### PR DESCRIPTION
also fixes a syntax error in css

see https://anvil.works/forum/t/m3-dropdown-not-displaying-as-expected-from-properties/22653

stacked ontop of #211