### PR TITLE
Fix: TextInput subcontent style properties work as intended

### DIFF
--- a/client_code/_Components/TextInput/__init__.py
+++ b/client_code/_Components/TextInput/__init__.py
@@ -37,7 +37,7 @@ class TextInput(TextInputTemplate):
       self.dom_nodes['anvil-m3-label-text'], "fontSize", self.label_font_size
     )
     spfs = get_unset_value(
-      self.dom_nodes['anvil-m3-supporting-text'],
+      self.dom_nodes['anvil-m3-subcontent'],
       "fontSize",
       self.subcontent_font_size,
     )


### PR DESCRIPTION
Closes #221

`supporting_text` and `character_limit` style properties are now combined into `subcontent` style properties 