### PR TITLE
Fix: The align property for TextBoxes and DropdownMenus now works as expected

### DIFF
--- a/client_code/_Components/DropdownMenu/__init__.py
+++ b/client_code/_Components/DropdownMenu/__init__.py
@@ -339,6 +339,10 @@ class DropdownMenu(DropdownMenuTemplate):
   @anvil_prop
   def appearance(self, value):
     self.selection_field.appearance = value
+  
+  @anvil_prop
+  def align(self, value):
+    self.selection_field.align = value
 
   @anvil_prop
   def role(self, value):

--- a/client_code/_Components/TextInput/TextBox.py
+++ b/client_code/_Components/TextInput/TextBox.py
@@ -307,7 +307,7 @@ class TextBox(TextInput):
       "type", "password" if value else self.type
     )
 
-  align = style_property('anvil-m3-textarea', 'textAlign', 'align')
+  align = style_property('anvil-m3-textbox', 'textAlign', 'align')
 
   #!componentProp(m3.TextBox)!1: {name:"align",type:"enum",options:["left", "right", "center"],description:"The position of this component in the available space."}
   #!componentProp(m3.TextBox)!1: {name:"appearance",type:"enum",options:["filled", "outlined"],description:"A predefined style for this component."}


### PR DESCRIPTION
Closes #200 

TextBoxes and DropdownMenus now have an align property that centers the input text.