### PR TITLE
Add change event to RadioGroupPanel's Object Palette

### DIFF
--- a/client_code/_Components/RadioGroupPanel/__init__.py
+++ b/client_code/_Components/RadioGroupPanel/__init__.py
@@ -4,8 +4,8 @@ from ._anvil_designer import RadioGroupPanelTemplate
 
 
 class RadioGroup(Component):
-  #TODO: why is this here?
-  # _anvil_events_ = [{"name": "change", "default_true": "True"}]
+
+  _anvil_events_ = [{"name": "change", "defaultEvent": True}]
 
   def __init__(self):
     self._buttons = []


### PR DESCRIPTION
Makes the `change` event the default event for the RadioGroupPanel so that it shows up in the Object Palette. Closes #220.