### PR TITLE
fix autocompletions

### DIFF
--- a/client_code/Layouts/NavigationDrawerLayout/__init__.py
+++ b/client_code/Layouts/NavigationDrawerLayout/__init__.py
@@ -142,13 +142,17 @@ class NavigationDrawerLayout(NavigationDrawerLayoutTemplate):
   )
 
   @anvil_prop
-  def background_color(self, value):
+  @property
+  def background_color(self, value) -> str:
+    """The background color of Forms using this Layout."""
     if value:
       value = theme_color_to_css(value)
     window.document.body.style.backgroundColor = value
 
   @anvil_prop
-  def text_color(self, value):
+  @property
+  def text_color(self, value) -> str:
+    """The default color of the text on Forms using this Layout."""
     if value:
       value = theme_color_to_css(value)
     window.document.body.style.color = value

--- a/client_code/Layouts/NavigationRailLayout/__init__.py
+++ b/client_code/Layouts/NavigationRailLayout/__init__.py
@@ -123,26 +123,34 @@ class NavigationRailLayout(NavigationRailLayoutTemplate):
   content_padding = padding_property('anvil-m3-content')
 
   @anvil_prop
-  def background_color(self, value):
+  @property
+  def background_color(self, value) -> str:
+    """The background color of Forms using this Layout."""
     if value:
       value = theme_color_to_css(value)
     window.document.body.style.backgroundColor = value
 
   @anvil_prop
-  def text_color(self, value):
+  @property
+  def text_color(self, value) -> str:
+    """The default color of the text on Forms using this Layout."""
     if value:
       value = theme_color_to_css(value)
     window.document.body.style.color = value
 
   @anvil_prop
-  def navigation_rail_collapse_to(self, value):
+  @property
+  def navigation_rail_collapse_to(self, value) -> str:
+    """The way the side navigation will collapse on mobile."""
     value = value.lower().replace('_', '-')
     for c in ['anvil-m3-bottom-app-bar', 'anvil-m3-modal-navigation-drawer']:
       self.nav_rail.classList.remove(c)
     self.nav_rail.classList.add(f"anvil-m3-{value}")
 
   @anvil_prop
-  def navigation_rail_vertical_align(self, value):
+  @property
+  def navigation_rail_vertical_align(self, value) -> str:
+    """The vertical position of the content in the navigation rail."""
     value = value.lower()
     for c in ['anvil-m3-align-top', 'anvil-m3-align-center', 'anvil-m3-align-bottom']:
       self.nav_rail.classList.remove(c)

--- a/client_code/_Components/Button/__init__.py
+++ b/client_code/_Components/Button/__init__.py
@@ -136,7 +136,9 @@ class Button(ButtonTemplate):
   visible = HtmlTemplate.visible
 
   @anvil_prop
-  def align(self, value):
+  @property
+  def align(self, value) -> str:
+    """The position of this component in the available space."""
     self.dom_nodes['anvil-m3-button'].classList.toggle('anvil-m3-full-width', False)
     if value == 'full':
       self.dom_nodes['anvil-m3-button'].classList.toggle('anvil-m3-full-width', True)
@@ -144,20 +146,26 @@ class Button(ButtonTemplate):
       self.dom_nodes['anvil-m3-button-component'].style.justifyContent = value
 
   @anvil_prop
-  def icon_align(self, value):
+  @property
+  def icon_align(self, value) -> str:
+    """The alignment of the icon on this component."""
     self.dom_nodes['anvil-m3-button'].classList.toggle(
       'anvil-m3-right-icon', value == 'right'
     )
 
   @anvil_prop
-  def enabled(self, value):
+  @property
+  def enabled(self, value) -> bool:
+    """If True, this component allows user interaction."""
     if value:
       self.dom_nodes['anvil-m3-button'].removeAttribute("disabled")
     else:
       self.dom_nodes['anvil-m3-button'].setAttribute("disabled", " ")
 
   @anvil_prop
-  def appearance(self, value):
+  @property
+  def appearance(self, value) -> str:
+    """A predefined style for this component."""
     button = self.dom_nodes['anvil-m3-button']
     button.classList.remove('anvil-m3-elevated')
     button.classList.remove('anvil-m3-filled')

--- a/client_code/_Components/ButtonMenu/__init__.py
+++ b/client_code/_Components/ButtonMenu/__init__.py
@@ -98,7 +98,9 @@ class ButtonMenu(ButtonMenuTemplate):
   visible = HtmlTemplate.visible
 
   @anvil_prop
-  def text(self, value):
+  @property
+  def text(self, value) -> str:
+    """The text displayed on the Button"""
     v = value
     self.menu_button.dom_nodes['anvil-m3-button-text'].classList.toggle(
       'anvil-m3-textlessComponentText', False
@@ -111,67 +113,99 @@ class ButtonMenu(ButtonMenuTemplate):
     self.menu_button.text = v
 
   @anvil_prop
-  def appearance(self, value):
+  @property
+  def appearance(self, value) -> str:
+    """A predefined style for the Button."""
     self.menu_button.appearance = value
 
   @anvil_prop
-  def tooltip(self, value):
+  @property
+  def tooltip(self, value) -> str:
+    """The text to display when the mouse is hovered over this component."""
     self.menu_button.tooltip = value
 
   @anvil_prop
-  def enabled(self, value):
+  @property
+  def enabled(self, value) -> bool:
+    """If True, this component allows user interaction."""
     self.menu_button.enabled = value
 
   @anvil_prop
-  def bold(self, value):
+  @property
+  def bold(self, value) -> bool:
+    """If True, the Button’s text will be bold."""
     self.menu_button.bold = value
 
   @anvil_prop
-  def italic(self, value):
+  @property
+  def italic(self, value) -> bool:
+    """If True, the Button’s text will be italic."""
     self.menu_button.italic = value
 
   @anvil_prop
-  def underline(self, value):
+  @property
+  def underline(self, value) -> bool:
+    """If True, the Button’s text will be underlined."""
     self.menu_button.underline = value
 
   @anvil_prop
-  def button_border(self, value):
+  @property
+  def button_border(self, value) -> str:
+    """The border of the Button. Can take any valid CSS border value."""
     self.menu_button.border = value
 
   @anvil_prop
-  def button_background_color(self, value):
+  @property
+  def button_background_color(self, value) -> str:
+    """The colour of the background of the Button."""
     self.menu_button.background_color = value
 
   @anvil_prop
-  def button_text_color(self, value):
+  @property
+  def button_text_color(self, value) -> str:
+    """The colour of the text on the Button."""
     self.menu_button.text_color = value
 
   @anvil_prop
-  def button_font_size(self, value):
+  @property
+  def button_font_size(self, value) -> int:
+    """The font size of the text displayed on the Button."""
     self.menu_button.font_size = value
 
   @anvil_prop
-  def icon(self, value):
+  @property
+  def icon(self, value) -> str:
+    """The icon to display on the Button."""
     self.menu_button.icon = value
 
   @anvil_prop
-  def icon_color(self, value):
+  @property
+  def icon_color(self, value) -> str:
+    """The colour of the icon displayed on the Button."""
     self.menu_button.icon_color = value
 
   @anvil_prop
-  def icon_size(self, value):
+  @property
+  def icon_size(self, value) -> int:
+    """The size (pixels) of the icon displayed on this component."""
     self.menu_button.icon_size = value
 
   @anvil_prop
-  def icon_position(self, value):
+  @property
+  def icon_position(self, value) -> str:
+    """The alignment of the icon on this component."""
     self.menu_button.icon_position = value
 
   @anvil_prop
-  def spacing(self, value):
+  @property
+  def spacing(self, value) -> list:
+    """The margin and padding (pixels) of the component."""
     self.menu_button.spacing = value
 
   @anvil_prop
-  def align(self, value):
+  @property
+  def align(self, value) -> str:
+    """The position of this component in the available space."""
     self.menu_button.dom_nodes['anvil-m3-button'].classList.toggle(
       'anvil-m3-full-width', False
     )
@@ -189,15 +223,21 @@ class ButtonMenu(ButtonMenuTemplate):
     self._setup_fui()
 
   @anvil_prop
-  def button_font_family(self, value):
+  @property
+  def button_font_family(self, value) -> str:
+    """The font family to use for the Button"""
     self.menu_button.font_family = value
 
   @anvil_prop
-  def role(self, value):
+  @property
+  def role(self, value) -> str:
+    """A style for this component defined in CSS and added to Roles"""
     self.menu_button.role = value
 
   @anvil_prop
-  def menu_items(self, value=[]):
+  @property
+  def menu_items(self, value=[]) -> list:
+    """A list of components to be added to the menu."""
     for i in value:
       self.add_component(i, slot='anvil-m3-buttonMenu-slot')
 

--- a/client_code/_Components/Card/__init__.py
+++ b/client_code/_Components/Card/__init__.py
@@ -34,13 +34,17 @@ class Card(CardTemplate):
     self.dom_nodes['content'].classList.toggle(f'anvil-m3-{appearance}', val)
 
   @anvil_prop
-  def appearance(self, value):
+  @property
+  def appearance(self, value) -> str:
+    """A predefined style for this component."""
     for appearance in ['outlined', 'filled', 'elevated']:
       self._set_class_of_nodes(appearance, False)
     self._set_class_of_nodes(value, True)
 
   @anvil_prop
-  def orientation(self, value):
+  @property
+  def orientation(self, value) -> str:
+    """The orientation of the content in this Card"""
     for c in ['anvil-m3-card-direction-column', 'anvil-m3-card-direction-row']:
       self.dom_nodes['anvil-m3-card'].classList.remove(c)
     self.dom_nodes['anvil-m3-card'].classList.add(f'anvil-m3-card-direction-{value}')

--- a/client_code/_Components/Checkbox/__init__.py
+++ b/client_code/_Components/Checkbox/__init__.py
@@ -16,6 +16,7 @@ from ..._utils.properties import (
   italic_property,
   role_property,
   spacing_property,
+  simple_prop,
   style_property,
   theme_color_to_css,
   tooltip_property,
@@ -130,10 +131,12 @@ class Checkbox(CheckboxTemplate):
   spacing = spacing_property('anvil-m3-checkbox-component')
   tooltip = tooltip_property('anvil-m3-checkbox-container')
   role = role_property('anvil-m3-checkbox-container')
-  allow_indeterminate = anvil_prop('allow_indeterminate')
+  allow_indeterminate = simple_prop('allow_indeterminate')
 
   @anvil_prop
-  def text(self, value):
+  @property
+  def text(self, value) -> str:
+    """The text displayed on this component"""
     if value:
       self.dom_nodes['anvil-m3-checkbox-label'].innerText = value
       self.dom_nodes['anvil-m3-checkbox-label'].style.display = 'block'
@@ -141,7 +144,9 @@ class Checkbox(CheckboxTemplate):
       self.dom_nodes['anvil-m3-checkbox-label'].style.display = 'none'
 
   @anvil_prop
-  def checkbox_color(self, value):
+  @property
+  def checkbox_color(self, value) -> str:
+    """The color of the checkbox."""
     if value:
       value = theme_color_to_css(value)
     self.dom_nodes['anvil-m3-checkbox-unchecked'].style.color = value
@@ -149,7 +154,9 @@ class Checkbox(CheckboxTemplate):
     self.dom_nodes['anvil-m3-checkbox-indeterminate'].style.color = value
 
   @anvil_prop
-  def checked(self, value):
+  @property
+  def checked(self, value) -> bool:
+    """If True, the checkbox is checked."""
     if value is None and self.allow_indeterminate:
       self.dom_nodes['anvil-m3-checkbox'].indeterminate = True
       self.dom_nodes['anvil-m3-checkbox-unchecked'].style.display = 'none'
@@ -167,7 +174,9 @@ class Checkbox(CheckboxTemplate):
       self.dom_nodes['anvil-m3-checkbox-indeterminate'].style.display = 'none'
 
   @anvil_prop
-  def error(self, value):
+  @property
+  def error(self, value) -> bool:
+    """If True, the checkbox is in an error state."""
     self.dom_nodes['anvil-m3-checkbox-container'].classList.remove(
       'anvil-m3-checkbox-error'
     )

--- a/client_code/_Components/CircularProgressIndicator/__init__.py
+++ b/client_code/_Components/CircularProgressIndicator/__init__.py
@@ -36,7 +36,9 @@ class CircularProgressIndicator(CircularProgressIndicatorTemplate):
   role = role_property('anvil-m3-progressindicator')
 
   @anvil_prop
-  def color(self, value):
+  @property
+  def color(self, value) -> str:
+    """The colour of the progress bar"""
     if value:
       value = theme_color_to_css(value)
     self.dom_nodes['anvil-m3-progressindicator-arc'].style['stroke'] = value
@@ -45,7 +47,9 @@ class CircularProgressIndicator(CircularProgressIndicatorTemplate):
     )
 
   @anvil_prop
-  def type(self, value):
+  @property
+  def type(self, value) -> str:
+    """Display a determinate or indeterminate progress indicator. Use determinate to set the progress with the progress property. Use indeterminate to express an unspecified amount of wait time."""
     v = value == "determinate"
     self.dom_nodes['anvil-m3-progressindicator-indeterminate'].classList.toggle(
       'anvil-m3-progressindicator-hidden', v
@@ -55,7 +59,9 @@ class CircularProgressIndicator(CircularProgressIndicatorTemplate):
     )
 
   @anvil_prop
-  def progress(self, value):
+  @property
+  def progress(self, value) -> float:
+    """The progress of the CircularProgressIndicator."""
     v = max(min(value or 0, 100), 0)
     self._draw_path(v)
 

--- a/client_code/_Components/Divider/__init__.py
+++ b/client_code/_Components/Divider/__init__.py
@@ -37,7 +37,9 @@ class Divider(DividerTemplate):
   margin = margin_property('anvil-m3-divider')
 
   @anvil_prop
-  def type(self, value):
+  @property
+  def type(self, value) -> str:
+    """Display the Divider across the full width of the container or inset."""
     divider = self.dom_nodes['anvil-m3-divider']
     value = value.lower().replace(' ', '-')
     divider.className = "anvil-m3-divider"

--- a/client_code/_Components/DropdownMenu/__init__.py
+++ b/client_code/_Components/DropdownMenu/__init__.py
@@ -301,115 +301,168 @@ class DropdownMenu(DropdownMenuTemplate):
   margin = margin_property('anvil-m3-dropdownMenu-textbox')
 
   @anvil_prop
-  def allow_none(self, value):
+  @property
+  def allow_none(self, value) -> bool:
+    """If True, a placeholder item is added to the menu with value None"""
     self._recreate_items()
 
   @anvil_prop
-  def background_color(self, value):
+  @property
+  def background_color(self, value) -> str:
+    """The colour of the background of this component."""
     self.selection_field.background_color = value
 
   @anvil_prop
-  def label_bold(self, value):
+  @property
+  def label_bold(self, value) -> bool:
+    """If True, the label text will be bold."""
     self.selection_field.label_bold = value
 
   @anvil_prop
-  def label_font(self, value):
+  @property
+  def label_font(self, value) -> str:
+    """The label text of the component."""
     self.selection_field.label_font = value
 
   @anvil_prop
-  def label_font_size(self, value):
+  @property
+  def label_font_size(self, value) -> float:
+    """The font size of the label text on this component."""
     self.selection_field.label_font_size = value
 
   @anvil_prop
-  def label_color(self, value):
+  @property
+  def label_color(self, value) -> str:
+    """The colour of the label text on the component."""
     self.selection_field.label_color = value
 
   @anvil_prop
-  def label_italic(self, value):
+  @property
+  def label_italic(self, value) -> bool:
+    """If True, the label text will be italic."""
     self.selection_field.label_italic = value
 
   @anvil_prop
-  def label_underline(self, value):
+  @property
+  def label_underline(self, value) -> bool:
+    """If True, the label text will be underlined."""
     self.selection_field.label_underline = value
 
   @anvil_prop
-  def enabled(self, value):
+  @property
+  def enabled(self, value) -> bool:
+    """If True, this component allows user interaction."""
     self.selection_field.enabled = value
 
   @anvil_prop
-  def appearance(self, value):
+  @property
+  def appearance(self, value) -> str:
+    """A predefined style for this component."""
     self.selection_field.appearance = value
-  
+
   @anvil_prop
-  def align(self, value):
+  @property
+  def align(self, value) -> str:
+    """The position of this component in the available space."""
     self.selection_field.align = value
 
   @anvil_prop
-  def role(self, value):
+  @property
+  def role(self, value) -> str:
+    """A style for this component defined in CSS and added to Roles"""
     self.selection_field.role = value
 
   @anvil_prop
-  def selected_italic(self, value):
+  @property
+  def selected_italic(self, value) -> bool:
+    """If True and there is a selected item, the displayed text in italic."""
     self.selection_field.display_italic = value
 
   @anvil_prop
-  def selected_bold(self, value):
+  @property
+  def selected_bold(self, value) -> bool:
+    """If True and there is a selected item, the displayed text is bold."""
     self.selection_field.display_bold = value
 
   @anvil_prop
-  def selected_underline(self, value):
+  @property
+  def selected_underline(self, value) -> bool:
+    """If True and there is a selected item, the displayed text is underlined"""
     self.selection_field.display_underline = value
 
   @anvil_prop
+  @property
   def selected_font(self, value):
     self.selection_field.selected_font = value
 
   @anvil_prop
-  def selected_font_size(self, value):
+  @property
+  def selected_font_size(self, value) -> int:
+    """The font size (pixels) of the displayed text if there is a selected item."""
     self.selection_field.selected_font_size = value
 
   @anvil_prop
-  def selected_text_color(self, value):
+  @property
+  def selected_text_color(self, value) -> str:
+    """The colour of the displayed text if there is a selected item."""
     self.selection_field.selected_text_color = value
 
   @anvil_prop
-  def icon(self, value):
+  @property
+  def icon(self, value) -> str:
     self.selection_field.leading_icon = value
 
   @anvil_prop
-  def icon_color(self, value):
+  @property
+  def icon_color(self, value) -> str:
     self.selection_field.leading_icon_color = value
 
   @anvil_prop
-  def tooltip(self, value):
+  @property
+  def tooltip(self, value) -> str:
+    """The text to display when the mouse is hovered over this component."""
     self.selection_field.tooltip = value
 
   @anvil_prop
-  def supporting_text(self, value):
+  @property
+  def supporting_text(self, value) -> str:
+    """The supporting text displayed below this component"""
     self.selection_field.supporting_text = value
 
   @anvil_prop
-  def supporting_text_color(self, value):
+  @property
+  def supporting_text_color(self, value) -> str:
+    """The colour of the supporting text below this component."""
     self.selection_field.subcontent_color = value
 
   @anvil_prop
-  def supporting_text_font_family(self, value):
+  @property
+  def supporting_text_font_family(self, value) -> str:
+    """The font family to use for the supporting text below this component."""
     self.selection_field.subcontent_font_family = value
 
   @anvil_prop
-  def supporting_text_font_size(self, value):
+  @property
+  def supporting_text_font_size(self, value) -> str:
+    """The font size of the supporting text displayed below this component."""
     self.selection_field.subcontent_font_size = value
 
   @anvil_prop
-  def border_color(self, value):
+  @property
+  def border_color(self, value) -> str:
+    """The colour of the border of this component."""
     self.selection_field.border_color = value
 
   @anvil_prop
-  def menu_background_color(self, value):
+  @property
+  def menu_background_color(self, value) -> str:
+    """The background color of the menu."""
     self.menu.background_color = value
 
   @anvil_prop
-  def error(self, value):
+  @property
+  def error(self, value) -> bool:
+    """If True, this component is in an error state."""
     if value:
       self.dom_nodes['anvil-m3-dropdownMenu-textbox'].classList.add(
         'anvil-m3-dropdown-error'
@@ -423,12 +476,16 @@ class DropdownMenu(DropdownMenuTemplate):
     self.selection_field.label = value
 
   @anvil_prop
-  def label(self, value):
+  @property
+  def label(self, value) -> str:
+    """The label text of the component."""
     self._set_label(value)
     self._set_designer_text_placeholder()
 
   @anvil_prop
+  @property
   def selected_value(self, value):
+    """The value of the currently selected item. Can only be set at runtime."""
     if anvil.designer.in_designer:
       return
 
@@ -443,7 +500,9 @@ class DropdownMenu(DropdownMenuTemplate):
         self.selection_field.text = ""
 
   @anvil_prop
-  def placeholder(self, value):
+  @property
+  def placeholder(self, value) -> str:
+    """The text to be displayed when the component is empty"""
     self.selection_field.placeholder = value
     self._recreate_items()
 
@@ -452,6 +511,7 @@ class DropdownMenu(DropdownMenuTemplate):
       self._create_menu_items()
 
   @anvil_prop
+  @property
   def items(self, value):
     items = value
     clean_items = self._clean_items = []
@@ -473,27 +533,39 @@ class DropdownMenu(DropdownMenuTemplate):
     self._recreate_items()
 
   @anvil_prop
-  def items_italic(self, value):
+  @property
+  def items_italic(self, value) -> bool:
+    """If True, the menu items will be italic."""
     self._recreate_items()
 
   @anvil_prop
-  def items_underline(self, value):
+  @property
+  def items_underline(self, value) -> bool:
+    """If True, the menu items will be underlined."""
     self._recreate_items()
 
   @anvil_prop
-  def items_text_color(self, value):
+  @property
+  def items_text_color(self, value) -> str:
+    """The colour of the menu items' text."""
     self._recreate_items()
 
   @anvil_prop
-  def items_bold(self, value):
+  @property
+  def items_bold(self, value) -> bool:
+    """If True, the menu items will be bold."""
     self._recreate_items()
 
   @anvil_prop
-  def items_font_family(self, value):
+  @property
+  def items_font_family(self, value) -> str:
+    """The font family to use for the menu items."""
     self._recreate_items()
 
   @anvil_prop
-  def items_font_size(self, value):
+  @property
+  def items_font_size(self, value) -> int:
+    """The font size of the menu items."""
     self._recreate_items()
 
   #!componentProp(m3.DropdownMenu)!1: {name:"align",type:"enum",options:["left", "right", "center"],description:"The position of this component in the available space."}

--- a/client_code/_Components/FileLoader/__init__.py
+++ b/client_code/_Components/FileLoader/__init__.py
@@ -15,6 +15,7 @@ from ..._utils.properties import (
   italic_property,
   role_property,
   spacing_property,
+  simple_prop,
   style_property,
   tooltip_property,
   underline_property,
@@ -156,12 +157,14 @@ class FileLoader(FileLoaderTemplate):
   spacing = spacing_property('anvil-m3-fileloader-container')
   tooltip = tooltip_property('anvil-m3-fileloader-container')
   role = role_property('anvil-m3-fileloader-container')
-  show_state = anvil_prop("show_state")
-  file = anvil_prop("file")
-  files = anvil_prop("files")
+  show_state = simple_prop("show_state")
+  file = simple_prop("file")
+  files = simple_prop("files")
 
   @anvil_prop
-  def appearance(self, value):
+  @property
+  def appearance(self, value) -> str:
+    """A predefined style for this component."""
     file_loader = self.dom_nodes['anvil-m3-fileloader-container']
     file_loader.classList.remove('anvil-m3-elevated')
     file_loader.classList.remove('anvil-m3-filled')
@@ -171,7 +174,9 @@ class FileLoader(FileLoaderTemplate):
       file_loader.classList.add(f"anvil-m3-{value}")
 
   @anvil_prop(default_value="mi:file_upload")
-  def icon(self, value):
+  @property
+  def icon(self, value) -> str:
+    """The icon to display on this component."""
     if value:
       self.dom_nodes['anvil-m3-fileloader-icon'].style.marginRight = "8px"
     else:
@@ -179,11 +184,15 @@ class FileLoader(FileLoaderTemplate):
     self.dom_nodes['anvil-m3-fileloader-icon'].innerText = value[3:]
 
   @anvil_prop
-  def file_types(self, value):
+  @property
+  def file_types(self, value) -> str:
+    """Specify what type of file to upload. Can accept a MIME type (eg 'image/png' or 'image/*'), an extension (eg '.png'), or a comma-separated set of them (eg '.png,.jpg,.jpeg')."""
     self.dom_nodes['anvil-m3-fileloader-input'].accept = value
 
   @anvil_prop
-  def multiple(self, value):
+  @property
+  def multiple(self, value) -> bool:
+    """If True, this FileLoader can load multiple files at the same time."""
     self.dom_nodes['anvil-m3-fileloader-input'].multiple = value
 
 

--- a/client_code/_Components/Heading/__init__.py
+++ b/client_code/_Components/Heading/__init__.py
@@ -100,7 +100,9 @@ class Heading(HeadingTemplate):
   role = role_property('anvil-m3-heading-container')
 
   @anvil_prop
-  def align(self, value):
+  @property
+  def align(self, value) -> str:
+    """The position of this component in the available space."""
     if value == 'justify':
       self.dom_nodes['anvil-m3-heading-container'].style.justifyContent = 'left'
     else:
@@ -108,7 +110,9 @@ class Heading(HeadingTemplate):
     self.dom_nodes['anvil-m3-heading-container'].style.textAlign = value
 
   @anvil_prop
-  def font_size(self, value):
+  @property
+  def font_size(self, value) -> int:
+    """The font size of text displayed on this component."""
     if value:
       self.dom_nodes['anvil-m3-heading-display'].style.fontSize = f'{value}px'
       self.dom_nodes['anvil-m3-heading-headline'].style.fontSize = f'{value}px'
@@ -121,13 +125,17 @@ class Heading(HeadingTemplate):
       self.dom_nodes['anvil-m3-heading-container'].style.fontSize = ''
 
   @anvil_prop
-  def icon_size(self, value):
+  @property
+  def icon_size(self, value) -> float:
+    """The size (pixels) of the icon displayed on this component."""
     if value:
       value = f'{value}px'
     self.dom_nodes['anvil-m3-heading-icon'].style.fontSize = value
 
   @anvil_prop
-  def underline(self, value):
+  @property
+  def underline(self, value) -> bool:
+    """If True, this component’s text will be underlined."""
     if value:
       self.dom_nodes['anvil-m3-heading-display'].style.textDecoration = 'underline'
       self.dom_nodes['anvil-m3-heading-headline'].style.textDecoration = 'underline'
@@ -138,7 +146,9 @@ class Heading(HeadingTemplate):
       self.dom_nodes['anvil-m3-heading-title'].style.textDecoration = 'none'
 
   @anvil_prop
-  def bold(self, value):
+  @property
+  def bold(self, value) -> bool:
+    """If True, this component’s text will be bold."""
     if value:
       self.dom_nodes['anvil-m3-heading-display'].style.fontWeight = 'bold'
       self.dom_nodes['anvil-m3-heading-headline'].style.fontWeight = 'bold'
@@ -149,12 +159,16 @@ class Heading(HeadingTemplate):
       self.dom_nodes['anvil-m3-heading-title'].style.fontWeight = 'normal'
 
   @anvil_prop
-  def text(self, value):
+  @property
+  def text(self, value) -> str:
+    """The text displayed on this component"""
     self._set_text(value)
     self._set_designer_text_placeholder()
 
   @anvil_prop
-  def icon(self, value):
+  @property
+  def icon(self, value) -> str:
+    """The icon to display on this component."""
     if value:
       self.dom_nodes['anvil-m3-heading-icon'].style.marginRight = "8px"
     else:
@@ -162,7 +176,9 @@ class Heading(HeadingTemplate):
     self.dom_nodes['anvil-m3-heading-icon'].innerText = value[3:]
 
   @anvil_prop
-  def style(self, value):
+  @property
+  def style(self, value) -> str:
+    """Role of the heading component: display, headline or title."""
     display = self.dom_nodes['anvil-m3-heading-display']
     headline = self.dom_nodes['anvil-m3-heading-headline']
     title = self.dom_nodes['anvil-m3-heading-title']
@@ -186,6 +202,7 @@ class Heading(HeadingTemplate):
       title.style.display = 'block'
 
   @anvil_prop
+  @property
   def scale(self, value):
     self.dom_nodes['anvil-m3-heading-display'].classList.remove(
       'anvil-m3-heading-large', 'anvil-m3-heading-medium', 'anvil-m3-heading-small'
@@ -211,10 +228,12 @@ class Heading(HeadingTemplate):
     )
 
   @anvil_prop
+  @property
   def spacing(self, value):
     set_element_spacing(self.dom_nodes['anvil-m3-heading-container'], value)
 
   @anvil_prop
+  @property
   def line_height(self, value):
     self.dom_nodes['anvil-m3-heading-display'].style.lineHeight = value
     self.dom_nodes['anvil-m3-heading-headline'].style.lineHeight = value

--- a/client_code/_Components/IconButton/__init__.py
+++ b/client_code/_Components/IconButton/__init__.py
@@ -73,11 +73,15 @@ class IconButton(IconButtonTemplate):
   tooltip = tooltip_property('anvil-m3-iconbutton-component')
 
   @anvil_prop
-  def icon(self, value):
+  @property
+  def icon(self, value) -> str:
+    """The icon to display on this component."""
     self.dom_nodes['anvil-m3-iconbutton-icon'].innerText = value[3:]
 
   @anvil_prop
-  def appearance(self, value):
+  @property
+  def appearance(self, value) -> str:
+    """A predefined style for this component."""
     self.dom_nodes['anvil-m3-iconbutton-container'].classList.toggle(
       "anvil-m3-filled", False
     )

--- a/client_code/_Components/InteractiveCard.py
+++ b/client_code/_Components/InteractiveCard.py
@@ -29,7 +29,9 @@ class InteractiveCard(Card):
     self.dom_nodes['anvil-m3-card'].addEventListener("click", self._handle_click)
 
   @anvil_prop
-  def enabled(self, value):
+  @property
+  def enabled(self, value) -> bool:
+    """If True, this component allows user interaction."""
     self.dom_nodes['anvil-m3-card'].classList.toggle('anvil-m3-disabled', not value)
 
   def _handle_click(self, event):

--- a/client_code/_Components/LinearProgressIndicator/__init__.py
+++ b/client_code/_Components/LinearProgressIndicator/__init__.py
@@ -30,7 +30,9 @@ class LinearProgressIndicator(LinearProgressIndicatorTemplate):
   margin = margin_property('anvil-m3-progressindicator-linear')
 
   @anvil_prop
-  def progress_color(self, value):
+  @property
+  def progress_color(self, value) -> str:
+    """The colour of the progress bar"""
     if value:
       value = theme_color_to_css(value)
     self.dom_nodes['anvil-m3-progressindicator-indicator'].style['stroke'] = value
@@ -42,7 +44,9 @@ class LinearProgressIndicator(LinearProgressIndicatorTemplate):
     ] = value
 
   @anvil_prop
-  def track_color(self, value):
+  @property
+  def track_color(self, value) -> str:
+    """The colour of the LinearProgressIndicator track."""
     if value:
       value = theme_color_to_css(value)
     self.dom_nodes[
@@ -53,7 +57,9 @@ class LinearProgressIndicator(LinearProgressIndicatorTemplate):
     ].style.backgroundColor = value
 
   @anvil_prop
-  def type(self, value):
+  @property
+  def type(self, value) -> str:
+    """Display a determinate or indeterminate progress indicator. Use determinate to set the progress with the progress property. Use indeterminate to express an unspecified amount of wait time."""
     v = value == "determinate"
     self.dom_nodes['anvil-m3-progressindicator-indeterminate'].classList.toggle(
       'anvil-m3-progressindicator-hidden', v
@@ -63,7 +69,9 @@ class LinearProgressIndicator(LinearProgressIndicatorTemplate):
     )
 
   @anvil_prop
-  def progress(self, value):
+  @property
+  def progress(self, value) -> float:
+    """The progress of the LinearProgressIndicator."""
     v = max(min(value or 0, 100), 0)
     self.dom_nodes['anvil-m3-progressindicator-indicator'].setAttribute("x2", f"{v}%")
 

--- a/client_code/_Components/Link/__init__.py
+++ b/client_code/_Components/Link/__init__.py
@@ -117,12 +117,16 @@ class Link(LinkTemplate):
   )
 
   @anvil_prop(default_value='left')
-  def align(self, value):
+  @property
+  def align(self, value) -> str:
+    """The position of this component in the available space."""
     self.dom_nodes['anvil-m3-link'].style.textAlign = value
     self.dom_nodes['anvil-m3-link-icon-container'].style.justifyContent = value
 
   @anvil_prop
-  def url(self, value):
+  @property
+  def url(self, value) -> str:
+    """TThe target URL of the link. Can be set to a URL string or to a Media object."""
     self.dom_nodes['anvil-m3-link'].removeAttribute("download")
     self.dom_nodes['anvil-m3-link'].removeAttribute("target")
     self._revoke_tmp_url()
@@ -139,13 +143,17 @@ class Link(LinkTemplate):
       self.dom_nodes['anvil-m3-link'].href = 'javascript:void(0)'
 
   @anvil_prop
-  def icon_size(self, value):
+  @property
+  def icon_size(self, value) -> str:
+    """The icon to display on this component."""
     if value:
       value = f'{value}px'
     self.dom_nodes['anvil-m3-link-icon'].style.fontSize = value
 
   @anvil_prop
-  def icon(self, value):
+  @property
+  def icon(self, value) -> str:
+    """The icon to display on this component."""
     if value and self.text:
       self.dom_nodes['anvil-m3-link-icon'].style.marginRight = "8px"
     else:
@@ -161,7 +169,9 @@ class Link(LinkTemplate):
       self.dom_nodes['anvil-m3-link-text'].style.display = 'none'
 
   @anvil_prop
-  def text(self, value):
+  @property
+  def text(self, value) -> str:
+    """The text displayed on this component."""
     self._set_text(value)
     self._set_designer_text_placeholder()
 

--- a/client_code/_Components/MenuItem/__init__.py
+++ b/client_code/_Components/MenuItem/__init__.py
@@ -54,11 +54,15 @@ class MenuItem(MenuItemTemplate):
   tooltip = tooltip_property('anvil-m3-menuItem-container')
 
   @anvil_prop
-  def text(self, value):
+  @property
+  def text(self, value) -> str:
+    """The text displayed on this component."""
     self.dom_nodes['anvil-m3-menuItem-labelText'].innerText = value
 
   @anvil_prop
-  def leading_icon(self, value):
+  @property
+  def leading_icon(self, value) -> str:
+    """The icon to display on this component."""
     self.dom_nodes["anvil-m3-menuItem-leadingIcon"].innerHTML = value[3:] or " "
     if value:
       self.dom_nodes["anvil-m3-menuItem-leadingIcon"].classList.add(
@@ -70,15 +74,21 @@ class MenuItem(MenuItemTemplate):
       )
 
   @anvil_prop
-  def trailing_icon(self, value):
+  @property
+  def trailing_icon(self, value) -> str:
+    """The icon to display on this component."""
     self.dom_nodes["anvil-m3-menuItem-trailingIcon"].innerText = value[3:]
 
   @anvil_prop
-  def trailing_text(self, value):
+  @property
+  def trailing_text(self, value) -> str:
+    """The text to be displayed on the right side of the component. Will be to the left of the trailing icon if both exist."""
     self.dom_nodes["anvil-m3-menuItem-trailingText"].innerText = value
 
   @anvil_prop
-  def add_icon_space(self, value):
+  @property
+  def add_icon_space(self, value) -> bool:
+    """If True, add a space where the leading_icon would be so that this MenuItem is aligned with MenuItems with leading_icons."""
     if value:
       self.dom_nodes["anvil-m3-menuItem-leadingIcon"].classList.add(
         "anvil-m3-menuItem-showLeadingIcon"
@@ -89,7 +99,9 @@ class MenuItem(MenuItemTemplate):
       )
 
   @anvil_prop
-  def enabled(self, value):
+  @property
+  def enabled(self, value) -> bool:
+    """If True, this component allows user interaction."""
     self.dom_nodes["anvil-m3-menuItem-container"].classList.toggle(
       "anvil-m3-menuItem-disabled", not value
     )

--- a/client_code/_Components/NavigationLink/__init__.py
+++ b/client_code/_Components/NavigationLink/__init__.py
@@ -14,6 +14,7 @@ from ..._utils.properties import (
   italic_property,
   role_property,
   spacing_property,
+  simple_prop,
   tooltip_property,
   underline_property,
 )
@@ -124,17 +125,21 @@ class NavigationLink(NavigationLinkTemplate):
   background_color = color_property(
     'anvil-m3-navigation-link-container', 'backgroundColor', 'background_color'
   )
-  navigate_to = anvil_prop("navigate_to")
+  navigate_to = simple_prop("navigate_to")
 
   @anvil_prop
-  def url(self, value):
+  @property
+  def url(self, value) -> str:
+    """TThe target URL of the link. Can be set to a URL string or to a Media object."""
     if value:
       self.dom_nodes['anvil-m3-navigation-link'].href = value
     else:
       self.dom_nodes['anvil-m3-navigation-link'].href = 'javascript:void(0)'
 
   @anvil_prop
-  def icon(self, value):
+  @property
+  def icon(self, value) -> str:
+    """The icon to display on this component."""
     link_icon = self.dom_nodes['anvil-m3-navigation-link-icon']
     if value:
       link_icon.className = ""
@@ -142,7 +147,9 @@ class NavigationLink(NavigationLinkTemplate):
       link_icon.innerText = value[3:]
 
   @anvil_prop
-  def selected(self, value):
+  @property
+  def selected(self, value) -> bool:
+    """If True, the component is in the selected state."""
     if value:
       self.dom_nodes['anvil-m3-navigation-link'].classList.add(
         'anvil-m3-navigation-link-selected'
@@ -153,14 +160,18 @@ class NavigationLink(NavigationLinkTemplate):
       )
 
   @anvil_prop
-  def badge(self, value):
+  @property
+  def badge(self, value) -> bool:
+    """If True, display a notification badge on the icon."""
     if value:
       self.dom_nodes['anvil-m3-navigation-link'].classList.add('anvil-m3-has-badge')
     else:
       self.dom_nodes['anvil-m3-navigation-link'].classList.remove('anvil-m3-has-badge')
 
   @anvil_prop
-  def badge_count(self, value):
+  @property
+  def badge_count(self, value) -> bool:
+    """If True, display a notification badge on the icon."""
     if value and self.badge:
       self.dom_nodes['anvil-m3-icon-badge'].innerHTML = value
       self.dom_nodes['anvil-m3-icon-badge'].classList.add("anvil-m3-large-badge")

--- a/client_code/_Components/RadioButton/__init__.py
+++ b/client_code/_Components/RadioButton/__init__.py
@@ -15,6 +15,7 @@ from ..._utils.properties import (
   inline_editing,
   italic_property,
   role_property,
+  simple_prop,
   spacing_property,
   style_property,
   theme_color_to_css,
@@ -85,7 +86,7 @@ class RadioButton(RadioButtonTemplate):
   # Properties
   enabled = enabled_property('anvil-m3-radiobutton-input')
   visible = HtmlTemplate.visible
-  value = anvil_prop('value')
+  value = simple_prop('value')
   underline = underline_property('anvil-m3-radiobutton-label')
   italic = italic_property('anvil-m3-radiobutton-label')
   bold = bold_property('anvil-m3-radiobutton-label')
@@ -105,12 +106,16 @@ class RadioButton(RadioButtonTemplate):
     self.dom_nodes['anvil-m3-radiobutton-label'].innerText = value
 
   @anvil_prop
-  def text(self, value):
+  @property
+  def text(self, value) -> str:
+    """The text displayed on this component"""
     self._set_text(value)
     self._set_designer_text_placeholder()
 
   @anvil_prop
-  def radio_color(self, value):
+  @property
+  def radio_color(self, value) -> str:
+    """The color of the radio button."""
     if value:
       value = theme_color_to_css(value)
     self.dom_nodes['anvil-m3-radiobutton-checked'].style['color'] = value

--- a/client_code/_Components/Slider/__init__.py
+++ b/client_code/_Components/Slider/__init__.py
@@ -10,6 +10,7 @@ from ..._utils.properties import (
   get_unset_margin,
   margin_property,
   role_property,
+  simple_prop,
   theme_color_to_css,
   tooltip_property,
 )
@@ -170,10 +171,12 @@ class Slider(SliderTemplate):
   tooltip = tooltip_property('anvil-m3-slider')
   visible = HtmlTemplate.visible
   role = role_property('anvil-m3-slider')
-  show_label = anvil_prop("show_label")
+  show_label = simple_prop("show_label")
 
   @anvil_prop
-  def thumb_color(self, value=None):
+  @property
+  def thumb_color(self, value=None) -> str:
+    """The colour of the slider thumb."""
     if self.thumb_color:
       self.dom_nodes['anvil-m3-slider-input'].style.setProperty(
         '--anvil-m3-slider-thumb-color', theme_color_to_css(self.thumb_color)
@@ -184,15 +187,21 @@ class Slider(SliderTemplate):
       )
 
   @anvil_prop
-  def label_color(self, value):
+  @property
+  def label_color(self, value) -> str:
+    """The colour of the background of the label"""
     self.label_container.style.background = theme_color_to_css(value)
 
   @anvil_prop
-  def label_text_color(self, value):
+  @property
+  def label_text_color(self, value) -> str:
+    """The colour of the text of the label"""
     self.label_container.style.color = theme_color_to_css(value)
 
   @anvil_prop
-  def enabled(self, value):
+  @property
+  def enabled(self, value) -> bool:
+    """If True, this component allows user interaction."""
     self._enabled = value
     full_slider = self.dom_nodes['anvil-m3-slider']
     input = self.dom_nodes['anvil-m3-slider-input']
@@ -204,7 +213,9 @@ class Slider(SliderTemplate):
       full_slider.classList.add("anvil-m3-slider-disabled")
 
   @anvil_prop
-  def show_markers(self, value):
+  @property
+  def show_markers(self, value) -> bool:
+    """If True, display discrete markers on the track."""
     if self._mounted:
       self._set_markers()
 

--- a/client_code/_Components/Switch/__init__.py
+++ b/client_code/_Components/Switch/__init__.py
@@ -132,7 +132,9 @@ class Switch(SwitchTemplate):
   )
 
   @anvil_prop
-  def selected_icon(self, value):
+  @property
+  def selected_icon(self, value) -> str:
+    """Optional icon to appear on the Switch when toggled on."""
     link_icon = self.dom_nodes['anvil-m3-enabled-switch-icon']
     switch_slider = self.dom_nodes['anvil-m3-switch-slider']
     link_icon.classList.remove("material-symbols-outlined")
@@ -142,7 +144,9 @@ class Switch(SwitchTemplate):
       switch_slider.classList.add('anvil-m3-has-enabled-icon')
 
   @anvil_prop
-  def unselected_icon(self, value):
+  @property
+  def unselected_icon(self, value) -> str:
+    """Optional icon to appear on the Switch when toggled off."""
     link_icon = self.dom_nodes['anvil-m3-disabled-switch-icon']
     switch_slider = self.dom_nodes['anvil-m3-switch-slider']
     link_icon.innerText = value[3:]
@@ -152,7 +156,9 @@ class Switch(SwitchTemplate):
       switch_slider.classList.add('anvil-m3-has-disabled-icon')
 
   @anvil_prop
-  def selected(self, value):
+  @property
+  def selected(self, value) -> bool:
+    """If True, this component is toggled on."""
     self.dom_nodes['anvil-m3-switch-input'].checked = value
     self._set_color_styles()
 

--- a/client_code/_Components/Text/__init__.py
+++ b/client_code/_Components/Text/__init__.py
@@ -97,12 +97,16 @@ class Text(TextTemplate):
   role = role_property('anvil-m3-text-container')
 
   @anvil_prop
-  def text(self, value):
+  @property
+  def text(self, value) -> str:
+    """The text displayed on this component"""
     self._set_text(value)
     self._set_designer_text_placeholder()
 
   @anvil_prop
-  def align(self, value):
+  @property
+  def align(self, value) -> str:
+    """The position of this component in the available space."""
     if value == 'justify':
       self.dom_nodes['anvil-m3-text-container'].style.justifyContent = 'left'
     else:
@@ -110,19 +114,25 @@ class Text(TextTemplate):
     self.dom_nodes['anvil-m3-text'].style.textAlign = value
 
   @anvil_prop
-  def font_size(self, value):
+  @property
+  def font_size(self, value) -> float:
+    """The font size of text displayed on this component."""
     if value:
       value = f'{value}px'
     self.dom_nodes['anvil-m3-text'].style.fontSize = value
     self.dom_nodes['anvil-m3-text-container'].style.fontSize = value
 
   @anvil_prop
-  def line_height(self, value):
+  @property
+  def line_height(self, value) -> str:
+    """The line height of this component."""
     self.dom_nodes['anvil-m3-text-container'].style.lineHeight = value
     self.dom_nodes['anvil-m3-text'].style.lineHeight = value
 
   @anvil_prop
-  def icon(self, value):
+  @property
+  def icon(self, value) -> str:
+    """The icon to display on this component."""
     if value:
       self.dom_nodes['anvil-m3-text-icon'].style.marginRight = "8px"
     else:
@@ -130,7 +140,9 @@ class Text(TextTemplate):
     self.dom_nodes['anvil-m3-text-icon'].innerText = value[3:]
 
   @anvil_prop
-  def style(self, value):
+  @property
+  def style(self, value) -> str:
+    """Role of the text component: display, headline or title."""
     self.dom_nodes['anvil-m3-text'].classList.remove(
       'anvil-m3-text-label', 'anvil-m3-text-body'
     )
@@ -141,7 +153,9 @@ class Text(TextTemplate):
     self.dom_nodes['anvil-m3-text-container'].classList.add(f'anvil-m3-text-{value}')
 
   @anvil_prop
-  def scale(self, value):
+  @property
+  def scale(self, value) -> str:
+    """The size of the text component."""
     self.dom_nodes['anvil-m3-text'].classList.remove(
       'anvil-m3-text-large', 'anvil-m3-text-medium', 'anvil-m3-text-small'
     )

--- a/client_code/_Components/TextInput/TextArea.py
+++ b/client_code/_Components/TextInput/TextArea.py
@@ -130,7 +130,9 @@ class TextArea(TextInput):
   align = style_property('anvil-m3-textarea', 'textAlign', 'align')
 
   @anvil_prop
-  def placeholder(self, value):
+  @property
+  def placeholder(self, value) -> str:
+    """The text to be displayed when the component is empty"""
     input = self.dom_nodes['anvil-m3-textarea']
     if value:
       input.placeholder = value
@@ -140,7 +142,9 @@ class TextArea(TextInput):
       input.classList.remove('anvil-m3-has-placeholder')
 
   @anvil_prop
-  def label(self, value):
+  @property
+  def label(self, value) -> str:
+    """The label text of the component."""
     self.dom_nodes['anvil-m3-label-text'].innerText = value or ""
     if value:
       self.dom_nodes['anvil-m3-textarea'].classList.toggle('has_label_text', True)
@@ -158,7 +162,9 @@ class TextArea(TextInput):
     self.dom_nodes['anvil-m3-textarea'].value = value
 
   @anvil_prop
-  def enabled(self, value):
+  @property
+  def enabled(self, value) -> bool:
+    """If True, this component allows user interaction."""
     supporting_text = self.dom_nodes['anvil-m3-subcontent']
     if value:
       self.dom_nodes['anvil-m3-textarea'].removeAttribute("disabled")
@@ -176,7 +182,9 @@ class TextArea(TextInput):
     self._set_height(value)
 
   @anvil_prop
-  def character_limit(self, value):
+  @property
+  def character_limit(self, value) -> float:
+    """The max number of characters a user can enter into this component. The limit is displayed below the component."""
     if value is None or value < 1:
       text_area_input = self.dom_nodes['anvil-m3-textarea'].removeAttribute("maxlength")
       self.dom_nodes['anvil-m3-character-counter'].style = "display: none"

--- a/client_code/_Components/TextInput/TextBox.py
+++ b/client_code/_Components/TextInput/TextBox.py
@@ -11,7 +11,7 @@ from ..._utils.properties import (
   italic_property,
   property_with_callback,
   underline_property,
-  style_property
+  style_property,
 )
 from . import TextInput
 
@@ -197,7 +197,9 @@ class TextBox(TextInput):
   )
 
   @anvil_prop
-  def placeholder(self, value):
+  @property
+  def placeholder(self, value) -> str:
+    """The text to be displayed when the component is empty"""
     input = self.dom_nodes['anvil-m3-textbox']
     if value:
       input.placeholder = value
@@ -218,7 +220,9 @@ class TextBox(TextInput):
     self.dom_nodes['anvil-m3-textbox'].value = value
 
   @anvil_prop
-  def label(self, value):
+  @property
+  def label(self, value) -> str:
+    """The label text of the component."""
     self.dom_nodes['anvil-m3-label-text'].innerText = value or ""
     if value:
       self.dom_nodes['anvil-m3-textbox'].classList.toggle('has_label_text', True)
@@ -228,7 +232,9 @@ class TextBox(TextInput):
       )
 
   @anvil_prop
-  def enabled(self, value):
+  @property
+  def enabled(self, value) -> bool:
+    """If True, this component allows user interaction."""
     supporting_text = self.dom_nodes['anvil-m3-subcontent']
     trailing_icon = self.dom_nodes['anvil-m3-trailing-icon']
     if value:
@@ -241,7 +247,9 @@ class TextBox(TextInput):
       trailing_icon.classList.add("anvil-m3-disable-icon")
 
   @anvil_prop
-  def error(self, value):
+  @property
+  def error(self, value) -> bool:
+    """If True, this component is in an error state."""
     super()._set_error(value)
     if value:
       icon = "mi:error"
@@ -253,7 +261,9 @@ class TextBox(TextInput):
       self.dom_nodes["anvil-m3-trailing-icon"].classList.remove("anvil-m3-error-icon")
 
   @anvil_prop
-  def leading_icon(self, value):
+  @property
+  def leading_icon(self, value) -> str:
+    """The leading icon to display on this component."""
     icon_container = self.dom_nodes['anvil-m3-icon-container']
     leading_icon = self.dom_nodes['anvil-m3-leading-icon']
     text_box_input = self.dom_nodes['anvil-m3-textbox']
@@ -286,7 +296,9 @@ class TextBox(TextInput):
   trailing_icon = property_with_callback('trailing_icon', _set_trailing_icon)
 
   @anvil_prop
-  def character_limit(self, value):
+  @property
+  def character_limit(self, value) -> float:
+    """The max number of characters a user can enter into this component. The limit is displayed below the component."""
     if value is None or value < 1:
       text_box_input = self.dom_nodes['anvil-m3-textbox'].removeAttribute("maxlength")
       self.dom_nodes['anvil-m3-character-counter'].style = "display: none"
@@ -298,11 +310,15 @@ class TextBox(TextInput):
       self.dom_nodes['anvil-m3-character-limit'].innerText = int(value)
 
   @anvil_prop
-  def type(self, value):
+  @property
+  def type(self, value) -> str:
+    """The type of data that the user can enter into this box."""
     self.dom_nodes['anvil-m3-textbox'].setAttribute("type", value)
 
   @anvil_prop
-  def hide_text(self, value):
+  @property
+  def hide_text(self, value) -> bool:
+    """If True, display stars instead of text when the user types input into this component."""
     self.dom_nodes['anvil-m3-textbox'].setAttribute(
       "type", "password" if value else self.type
     )

--- a/client_code/_Components/TextInput/__init__.py
+++ b/client_code/_Components/TextInput/__init__.py
@@ -91,9 +91,7 @@ class TextInput(TextInputTemplate):
   label_color = color_property('anvil-m3-label-text', 'color', 'label_color')
   margin = margin_property('anvil-m3-textinput')
   tooltip = tooltip_property('anvil-m3-textinput')
-  subcontent_color = color_property(
-    'anvil-m3-subcontent', 'color', 'subcontent_color'
-  )
+  subcontent_color = color_property('anvil-m3-subcontent', 'color', 'subcontent_color')
   subcontent_font_family = font_family_property(
     'anvil-m3-subcontent', 'subcontent_font_family'
   )
@@ -102,6 +100,7 @@ class TextInput(TextInputTemplate):
   )
 
   @anvil_prop
+  @property
   def appearance(self, value):
     if value == 'outlined':
       self.dom_nodes['anvil-m3-textinput'].classList.toggle('outlined', True)
@@ -109,6 +108,7 @@ class TextInput(TextInputTemplate):
       self.dom_nodes['anvil-m3-textinput'].classList.toggle('outlined', False)
 
   @anvil_prop
+  @property
   def supporting_text(self, value):
     self.dom_nodes['anvil-m3-supporting-text'].innerHTML = value
 
@@ -122,6 +122,7 @@ class TextInput(TextInputTemplate):
   error = property_with_callback('error', _set_error)
 
   @anvil_prop
+  @property
   def border_color(self, value):
     if self.border_color:
       self.dom_nodes["anvil-m3-textinput"].style.setProperty(

--- a/client_code/_utils/properties.py
+++ b/client_code/_utils/properties.py
@@ -263,36 +263,32 @@ def tooltip_property(dom_node_name, prop_name="tooltip"):
   return property_with_callback(prop_name, set_tooltip)
 
 
+simple_prop = property_without_callback
+
 def anvil_prop(*args, **kwargs):
   """
-  Can be used to return a property descriptor for a named property:
-
-    my_property = anvil_prop("my_property")
-
   Can be used as a plain decorator on a property setter:
 
     @anvil_prop
+    @property
     def my_property(new_value):
       ...
 
-  In both cases, you can pass a default_value kwarg if required:
-
-    my_property = anvil_prop("my_property", default_value=42)
-
     @anvil_prop(default_value=42)
+    @property
     def my_property(new_value):
       ...
   """
 
   def get_decorator(default_value=None):
-    return lambda fn: property_with_callback(
-      fn.__name__, fn, default_value=default_value
-    )
+    def decorator(prop):
+      assert isinstance(prop, property), "expected an @property decorator"
+      fn = prop.fget
+      return property_with_callback(fn.__name__, fn, default_value=default_value)
 
-  if len(args) > 0 and isinstance(args[0], str):
-    # We have been called as a function, with the name of the property as our first arg
-    return property_without_callback(args[0], default_value=kwargs.get("default_value"))
-  elif len(args) == 0:
+    return decorator
+
+  if not args:
     # We have been used as a decorator with kwargs
     return get_decorator(kwargs.get("default_value"))
   else:


### PR DESCRIPTION
close #201 

Approach:
- I wrote a script to do the replacement

before
```python
  @anvil_prop
  def align(self, value):
    ...

  #!componentProp(m3.Button)!1: {name:"align",type:"enum",options:["left", "right", "center"],description:"The position of this component in the available space."}

```
after
```python
  @anvil_prop
  @property
  def align(self, value) -> str:
    """The position of this component in the available space."""
    ...

  #!componentProp(m3.Button)!1: {name:"align",type:"enum",options:["left", "right", "center"],description:"The position of this component in the available space."}

```

- I checked the autocompletions worked
- I checked for the code still loaded by doing `import m3.components as m3` in a client repl

---

Worth checking the change to `_utils.properties`
We only use anvil_prop as a decorator now

before
```python
  show_label = anvil_prop("show_label")
```
after
```python
  show_label = simple_prop("show_label")
```


This seems to be enough for the autocompleter to work as expected
while maintaining the existing helpers
