### PR TITLE
Fix: Bottom app bar no longer overlays content

### DIFF
--- a/client_code/Layouts/NavigationRailLayout/__init__.py
+++ b/client_code/Layouts/NavigationRailLayout/__init__.py
@@ -139,7 +139,9 @@ class NavigationRailLayout(NavigationRailLayoutTemplate):
     value = value.lower().replace('_', '-')
     for c in ['anvil-m3-bottom-app-bar', 'anvil-m3-modal-navigation-drawer']:
       self.nav_rail.classList.remove(c)
+      self.content.classList.remove(c)
     self.nav_rail.classList.add(f"anvil-m3-{value}")
+    self.content.classList.add()
 
   @anvil_prop
   def navigation_rail_vertical_align(self, value):

--- a/client_code/Layouts/NavigationRailLayout/__init__.py
+++ b/client_code/Layouts/NavigationRailLayout/__init__.py
@@ -141,7 +141,7 @@ class NavigationRailLayout(NavigationRailLayoutTemplate):
       self.nav_rail.classList.remove(c)
       self.content.classList.remove(c)
     self.nav_rail.classList.add(f"anvil-m3-{value}")
-    self.content.classList.add()
+    self.content.classList.add(f"anvil-m3-{value}")
 
   @anvil_prop
   def navigation_rail_vertical_align(self, value):

--- a/theme/assets/theme.css
+++ b/theme/assets/theme.css
@@ -467,27 +467,27 @@ body {
 
 
 @media(max-width: 600px) {
-.anvil-m3-navigation-rail.anvil-m3-bottom-app-bar .anvil-m3-navigation-rail-content {
-      margin-top: 0px;
-      flex-direction: row;
-      width: 100%;
-      height: 80px;
-      justify-content: center;
-      column-gap: 8px
-  }
+  .anvil-m3-navigation-rail.anvil-m3-bottom-app-bar .anvil-m3-navigation-rail-content {
+    margin-top: 0px;
+    flex-direction: row;
+    width: 100%;
+    height: 80px;
+    justify-content: center;
+    column-gap: 8px
+    }
 }
 
 @media(max-width: 600px) {
-.anvil-m3-content..anvil-m3-navigation-rail-content.anvil-m3-bottom-app-bar  {
-
+  .anvil-m3-content.anvil-m3-content-navigation-rail.anvil-m3-bottom-app-bar  {
+    margin-bottom: 80px;
+    }
   }
-}
 
 
 @media(max-width: 600px) {
-.anvil-m3-navigation-rail.anvil-m3-modal-navigation-drawer .anvil-m3-navigation-rail-content {
-      width: 100%;
-  }
+  .anvil-m3-navigation-rail.anvil-m3-modal-navigation-drawer .anvil-m3-navigation-rail-content {
+    width: 100%;
+    }
 }
 
 .anvil-m3-navigation-rail [anvil-dropzone] {

--- a/theme/assets/theme.css
+++ b/theme/assets/theme.css
@@ -478,6 +478,13 @@ body {
 }
 
 @media(max-width: 600px) {
+.anvil-m3-content..anvil-m3-navigation-rail-content.anvil-m3-bottom-app-bar  {
+
+  }
+}
+
+
+@media(max-width: 600px) {
 .anvil-m3-navigation-rail.anvil-m3-modal-navigation-drawer .anvil-m3-navigation-rail-content {
       width: 100%;
   }


### PR DESCRIPTION
Closes #232 

When on mobile, the main content now has a bottom margin to make space for the bottom app bar