### PR TITLE
Improve theme colors

### DIFF
--- a/client_code/_utils/properties.py
+++ b/client_code/_utils/properties.py
@@ -1,5 +1,7 @@
 import anvil.designer
 from anvil import *
+import anvil
+from anvil.js import get_dom_node
 from anvil.js.window import document
 from anvil.property_utils import (
   get_margin_styles,
@@ -24,12 +26,13 @@ class ComponentTag:
     return f"ComponentTag({self.__dict__})"
 
 
+_TB = anvil.TextBox()
+_TB_NODE = get_dom_node(_TB)
+
+
 def theme_color_to_css(color: str):
-  if color.startswith('theme:'):
-    color = color.lstrip('theme:')
-    return app.theme_colors[color]
-  else:
-    return color
+  _TB.foreground = color
+  return _TB_NODE.style.color
 
 
 """ REUSABLE PROPERTIES """


### PR DESCRIPTION
At the moment if a user sets a color property to a `theme:X` color, then it is not dynamic.
By which I mean, if the user updates the `app.theme_colors` at runtime, the color will not apply

Reproduce:
- add a button
- set the background color to `theme:Primary`
- at runtime in the running app console do `app.theme_colors["Primary"] = "red"`
- observe the backgorund color does not change

This PR fixes the above issue by using an anvil TextBox as the intermediary 
The TextBox does the hard work of working with a theme color and turning into a dynamic css var so we don't have to

