### PR TITLE
use existing role implementation rather than rolling our own

### DIFF
--- a/client_code/_Components/Button/__init__.py
+++ b/client_code/_Components/Button/__init__.py
@@ -14,7 +14,6 @@ from ..._utils.properties import (
   get_unset_value,
   italic_property,
   property_with_callback,
-  role_property,
   spacing_property,
   style_property,
   tooltip_property,
@@ -117,7 +116,6 @@ class Button(ButtonTemplate):
       else:
         self.dom_nodes['anvil-m3-button-text'].innerText = ""
 
-  role = role_property('anvil-m3-button')
   text = property_with_callback("text", _update_button_look)
   icon = property_with_callback("icon", _update_button_look)
   text_color = color_property('anvil-m3-button-text', 'color', 'text_color')
@@ -135,6 +133,7 @@ class Button(ButtonTemplate):
   border = style_property('anvil-m3-button', 'border', 'border')
   tooltip = tooltip_property('anvil-m3-button')
   visible = HtmlTemplate.visible
+  role = HtmlTemplate.role
 
   @anvil_prop
   @property

--- a/client_code/_Components/ButtonMenu/__init__.py
+++ b/client_code/_Components/ButtonMenu/__init__.py
@@ -228,11 +228,7 @@ class ButtonMenu(ButtonMenuTemplate):
     """The font family to use for the Button"""
     self.menu_button.font_family = value
 
-  @anvil_prop
-  @property
-  def role(self, value) -> str:
-    """A style for this component defined in CSS and added to Roles"""
-    self.menu_button.role = value
+  role = HtmlTemplate.role
 
   @anvil_prop
   @property

--- a/client_code/_Components/Card/__init__.py
+++ b/client_code/_Components/Card/__init__.py
@@ -5,7 +5,6 @@ from ..._utils.properties import (
   anvil_prop,
   color_property,
   get_unset_spacing,
-  role_property,
   spacing_property,
   style_property,
   tooltip_property,
@@ -52,9 +51,9 @@ class Card(CardTemplate):
   spacing = spacing_property('anvil-m3-card')
   tooltip = tooltip_property('anvil-m3-card')
   border = style_property('anvil-m3-card', 'border', 'border')
-  role = role_property('anvil-m3-card')
   align = style_property('anvil-m3-card', 'justifyContent', 'align')
   visible = HtmlTemplate.visible
+  role = HtmlTemplate.role
   background_color = color_property(
     'anvil-m3-card', 'backgroundColor', 'background_color'
   )

--- a/client_code/_Components/Checkbox/__init__.py
+++ b/client_code/_Components/Checkbox/__init__.py
@@ -14,7 +14,6 @@ from ..._utils.properties import (
   get_unset_spacing,
   get_unset_value,
   italic_property,
-  role_property,
   spacing_property,
   simple_prop,
   style_property,
@@ -117,6 +116,7 @@ class Checkbox(CheckboxTemplate):
 
   enabled = enabled_property('anvil-m3-checkbox')
   visible = HtmlTemplate.visible
+  role = HtmlTemplate.role
   underline = underline_property('anvil-m3-checkbox-label')
   italic = italic_property('anvil-m3-checkbox-label')
   bold = bold_property('anvil-m3-checkbox-label')
@@ -130,7 +130,6 @@ class Checkbox(CheckboxTemplate):
   align = style_property('anvil-m3-checkbox-component', 'justifyContent', 'align')
   spacing = spacing_property('anvil-m3-checkbox-component')
   tooltip = tooltip_property('anvil-m3-checkbox-container')
-  role = role_property('anvil-m3-checkbox-container')
   allow_indeterminate = simple_prop('allow_indeterminate')
 
   @anvil_prop

--- a/client_code/_Components/CircularProgressIndicator/__init__.py
+++ b/client_code/_Components/CircularProgressIndicator/__init__.py
@@ -7,7 +7,6 @@ from ..._utils.properties import (
   anvil_prop,
   get_unset_margin,
   margin_property,
-  role_property,
   style_property,
   theme_color_to_css,
   tooltip_property,
@@ -33,7 +32,7 @@ class CircularProgressIndicator(CircularProgressIndicatorTemplate):
   )
   margin = margin_property('anvil-m3-progressindicator-component')
   tooltip = tooltip_property('anvil-m3-progressindicator')
-  role = role_property('anvil-m3-progressindicator')
+  role = HtmlTemplate.role
 
   @anvil_prop
   @property

--- a/client_code/_Components/Divider/__init__.py
+++ b/client_code/_Components/Divider/__init__.py
@@ -5,7 +5,6 @@ from ..._utils.properties import (
   color_property,
   get_unset_margin,
   margin_property,
-  role_property,
 )
 from ._anvil_designer import DividerTemplate
 
@@ -33,7 +32,7 @@ class Divider(DividerTemplate):
 
   visible = HtmlTemplate.visible
   color = color_property('anvil-m3-divider', 'border-color', 'color')
-  role = role_property('anvil-m3-divider')
+  role = HtmlTemplate.role
   margin = margin_property('anvil-m3-divider')
 
   @anvil_prop

--- a/client_code/_Components/DropdownMenu/__init__.py
+++ b/client_code/_Components/DropdownMenu/__init__.py
@@ -298,6 +298,7 @@ class DropdownMenu(DropdownMenuTemplate):
 
   # properties
   visible = anvil.HtmlTemplate.visible
+  role = anvil.HtmlTemplate.role
   margin = margin_property('anvil-m3-dropdownMenu-textbox')
 
   @anvil_prop
@@ -365,18 +366,6 @@ class DropdownMenu(DropdownMenuTemplate):
   def align(self, value) -> str:
     """The position of this component in the available space."""
     self.selection_field.align = value
-
-  @anvil_prop
-  @property
-  def role(self, value) -> str:
-    """A style for this component defined in CSS and added to Roles"""
-    self.selection_field.role = value
-
-  @anvil_prop
-  @property
-  def selected_italic(self, value) -> bool:
-    """If True and there is a selected item, the displayed text in italic."""
-    self.selection_field.display_italic = value
 
   @anvil_prop
   @property

--- a/client_code/_Components/FileLoader/__init__.py
+++ b/client_code/_Components/FileLoader/__init__.py
@@ -13,7 +13,6 @@ from ..._utils.properties import (
   get_unset_value,
   innerText_property,
   italic_property,
-  role_property,
   simple_prop,
   spacing_property,
   style_property,
@@ -158,7 +157,7 @@ class FileLoader(FileLoaderTemplate):
   border = style_property('anvil-m3-fileloader-container', 'border', 'border')
   spacing = spacing_property('anvil-m3-fileloader-container')
   tooltip = tooltip_property('anvil-m3-fileloader-container')
-  role = role_property('anvil-m3-fileloader-container')
+  role = HtmlTemplate.role
   show_state = simple_prop("show_state")
   file = simple_prop("file")
   files = simple_prop("files")

--- a/client_code/_Components/Heading/__init__.py
+++ b/client_code/_Components/Heading/__init__.py
@@ -11,7 +11,6 @@ from ..._utils.properties import (
   get_unset_value,
   inline_editing,
   italic_property,
-  role_property,
   tooltip_property,
 )
 from ._anvil_designer import HeadingTemplate
@@ -97,7 +96,7 @@ class Heading(HeadingTemplate):
     'anvil-m3-heading-container', 'backgroundColor', 'background_color'
   )
   tooltip = tooltip_property('anvil-m3-heading-container')
-  role = role_property('anvil-m3-heading-container')
+  role = anvil.HtmlTemplate.role
 
   @anvil_prop
   @property

--- a/client_code/_Components/IconButton/__init__.py
+++ b/client_code/_Components/IconButton/__init__.py
@@ -9,7 +9,6 @@ from ..._utils.properties import (
   enabled_property,
   get_unset_margin,
   margin_property,
-  role_property,
   style_property,
   tooltip_property,
 )
@@ -69,7 +68,7 @@ class IconButton(IconButtonTemplate):
     'anvil-m3-iconbutton-container', 'backgroundColor', 'background_color'
   )
   margin = margin_property('anvil-m3-iconbutton-container')
-  role = role_property('anvil-m3-iconbutton-container')
+  role = HtmlTemplate.role
   tooltip = tooltip_property('anvil-m3-iconbutton-component')
 
   @anvil_prop

--- a/client_code/_Components/LinearProgressIndicator/__init__.py
+++ b/client_code/_Components/LinearProgressIndicator/__init__.py
@@ -5,7 +5,6 @@ from ..._utils.properties import (
   anvil_prop,
   get_unset_margin,
   margin_property,
-  role_property,
   theme_color_to_css,
   tooltip_property,
 )
@@ -26,7 +25,7 @@ class LinearProgressIndicator(LinearProgressIndicatorTemplate):
 
   visible = HtmlTemplate.visible
   tooltip = tooltip_property('anvil-m3-progressindicator-linear')
-  role = role_property('anvil-m3-progressindicator-linear')
+  role = HtmlTemplate.role
   margin = margin_property('anvil-m3-progressindicator-linear')
 
   @anvil_prop

--- a/client_code/_Components/Link/__init__.py
+++ b/client_code/_Components/Link/__init__.py
@@ -9,7 +9,6 @@ from ..._utils.properties import (
   font_size_property,
   inline_editing,
   italic_property,
-  role_property,
   spacing_property,
   style_property,
   tooltip_property,
@@ -111,7 +110,7 @@ class Link(LinkTemplate):
   border = style_property('anvil-m3-link', 'border', 'border')
   spacing = spacing_property('anvil-m3-link')
   tooltip = tooltip_property('anvil-m3-link')
-  role = role_property('anvil-m3-link')
+  role = anvil.HtmlTemplate.role
   background_color = color_property(
     'anvil-m3-link', 'backgroundColor', 'background_color'
   )

--- a/client_code/_Components/MenuItem/__init__.py
+++ b/client_code/_Components/MenuItem/__init__.py
@@ -50,6 +50,7 @@ class MenuItem(MenuItemTemplate):
     'anvil-m3-menuItem-container', 'backgroundColor', 'background'
   )
   visible = HtmlTemplate.visible
+  role = HtmlTemplate.role
   spacing = spacing_property('anvil-m3-menuItem-container')
   tooltip = tooltip_property('anvil-m3-menuItem-container')
 

--- a/client_code/_Components/NavigationLink/__init__.py
+++ b/client_code/_Components/NavigationLink/__init__.py
@@ -12,7 +12,6 @@ from ..._utils.properties import (
   get_unset_value,
   innerHTML_property,
   italic_property,
-  role_property,
   spacing_property,
   simple_prop,
   tooltip_property,
@@ -111,7 +110,7 @@ class NavigationLink(NavigationLinkTemplate):
 
   visible = HtmlTemplate.visible
   text = innerHTML_property('anvil-m3-navigation-link-text')
-  role = role_property('anvil-m3-navigation-link')
+  role = HtmlTemplate.role
   italic = italic_property('anvil-m3-navigation-link-text')
   bold = bold_property('anvil-m3-navigation-link-text')
   underline = underline_property('anvil-m3-navigation-link-text')

--- a/client_code/_Components/RadioButton/__init__.py
+++ b/client_code/_Components/RadioButton/__init__.py
@@ -14,7 +14,6 @@ from ..._utils.properties import (
   font_size_property,
   inline_editing,
   italic_property,
-  role_property,
   simple_prop,
   spacing_property,
   style_property,
@@ -100,7 +99,7 @@ class RadioButton(RadioButtonTemplate):
   align = style_property('anvil-m3-radiobutton-component', 'justifyContent', 'align')
   spacing = spacing_property('anvil-m3-radiobutton-component')
   tooltip = tooltip_property('anvil-m3-radiobutton-component')
-  role = role_property('anvil-m3-radiobutton-container')
+  role = HtmlTemplate.role
 
   def _set_text(self, value):
     self.dom_nodes['anvil-m3-radiobutton-label'].innerText = value

--- a/client_code/_Components/Slider/__init__.py
+++ b/client_code/_Components/Slider/__init__.py
@@ -9,7 +9,6 @@ from ..._utils.properties import (
   color_property,
   get_unset_margin,
   margin_property,
-  role_property,
   simple_prop,
   theme_color_to_css,
   tooltip_property,
@@ -170,7 +169,7 @@ class Slider(SliderTemplate):
   margin = margin_property("anvil-m3-slider")
   tooltip = tooltip_property('anvil-m3-slider')
   visible = HtmlTemplate.visible
-  role = role_property('anvil-m3-slider')
+  role = HtmlTemplate.role
   show_label = simple_prop("show_label")
 
   @anvil_prop

--- a/client_code/_Components/Switch/__init__.py
+++ b/client_code/_Components/Switch/__init__.py
@@ -9,7 +9,6 @@ from ..._utils.properties import (
   get_unset_margin,
   margin_property,
   property_with_callback,
-  role_property,
   style_property,
   theme_color_to_css,
   tooltip_property,
@@ -114,7 +113,7 @@ class Switch(SwitchTemplate):
   visible = HtmlTemplate.visible
   margin = margin_property('anvil-m3-switch-container')
   tooltip = tooltip_property('anvil-m3-switch')
-  role = role_property('anvil-m3-switch')
+  role = HtmlTemplate.role
   selected_background_color = property_with_callback(
     'selected_background_color', _set_color_styles
   )

--- a/client_code/_Components/Text/__init__.py
+++ b/client_code/_Components/Text/__init__.py
@@ -12,7 +12,6 @@ from ..._utils.properties import (
   get_unset_value,
   inline_editing,
   italic_property,
-  role_property,
   spacing_property,
   tooltip_property,
   underline_property,
@@ -94,7 +93,7 @@ class Text(TextTemplate):
   icon_size = font_size_property('anvil-m3-text-icon', 'icon_size')
   spacing = spacing_property('anvil-m3-text-container')
   tooltip = tooltip_property('anvil-m3-text-container')
-  role = role_property('anvil-m3-text-container')
+  role = anvil.HtmlTemplate.role
 
   @anvil_prop
   @property

--- a/client_code/_Components/TextInput/__init__.py
+++ b/client_code/_Components/TextInput/__init__.py
@@ -83,6 +83,7 @@ class TextInput(TextInputTemplate):
     ]
 
   visible = HtmlTemplate.visible
+  role = HtmlTemplate.role
   label_italic = italic_property('anvil-m3-label-text', 'label_italic')
   label_bold = bold_property('anvil-m3-label-text', 'label_bold')
   label_underline = underline_property('anvil-m3-label-text', 'label_underline')

--- a/client_code/_utils/properties.py
+++ b/client_code/_utils/properties.py
@@ -203,25 +203,6 @@ def padding_property(dom_node_name, prop_name="padding"):
   return property_with_callback(prop_name, set_padding)
 
 
-def role_property(dom_node_name, prop_name="role"):
-  def set_role(self, value):
-    element = self.dom_nodes[dom_node_name]
-    class_list = element.classList
-    for c in class_list:
-      if c.startswith('anvil-role'):
-        element.classList.remove(c)
-    if value:
-      element.setAttribute('anvil-role', value)
-      if type(value) is str:
-        element.classList.add(f'anvil-role-{value}')
-        element.setAttribute('anvil-role', value)
-      elif type(value) is list:
-        for role in value:
-          element.classList.add(f'anvil-role-{role}')
-
-  return property_with_callback(prop_name, set_role)
-
-
 def tooltip_property(dom_node_name, prop_name="tooltip"):
   # To use this property, add self._tooltip_node = None to the init of your component
   def set_tooltip(self, value):


### PR DESCRIPTION
This change is potentially breaking - but since we're still in beta that's probably ok and would recommend doing a minor version bump.

But also - feel free to close this issue if it's not a desired change
I like that it's consistent (you will always get a role on the outer component)
but i see the advantages of the current approach

we were missing role property on text input and menu button (https://anvil.works/forum/t/m3-legacy-read-only-role-not-working-with-m3-dependency/23911/5)
this PR implements the role prop in the same way we implement the visible prop
i.e. bypass our form template custom component descriptor and instead use the HtmlTemplate's role descriptor.

This will change where the `.anvil-role-X` class is applied, and so users may find their current role code breaks, and will need to change code from 

```css
.anvil-role-my-role {
    color: red;
}
```
to something like

```css
.anvil-role-my-role .anvil-m3-some-class {
    color: red;
}
/* or  something like*/
.anvil-role-my-role button {
    color: red;
}

```

This might not be the approach we actually want to take
so feel free to close this, and instead we can just add the missing role properties to `TextInput` and `MenuItem`