### PR TITLE
fix avatar pixelation on chromium-based browsers

### DIFF
--- a/theme/assets/anvil-m3/avatar.css
+++ b/theme/assets/anvil-m3/avatar.css
@@ -38,6 +38,7 @@
   width: 40px;
   border-radius: 50%;
   object-fit: cover;
+  overflow-clip-margin: unset;
 }
 
 


### PR DESCRIPTION
Changes made:
- added `overflow-clip-margin: unset;` to `.anvil-m3-avatar img.anvil-m3-avatar-image`

Why were they made:
- to fix the avatar pixelation caused on chromium-based browsers when resizing certain images

Related issue
- https://github.com/anvil-works/material-3-theme/issues/280