### PR TITLE
Add "full" as an option for the align property of the FileLoader

### DIFF
--- a/client_code/_Components/Card/CardContentContainer/form_template.yaml
+++ b/client_code/_Components/Card/CardContentContainer/form_template.yaml
@@ -8,6 +8,7 @@ container:
   type: HtmlTemplate
 custom_component: true
 custom_component_container: true
+events: []
 is_package: true
 properties:
 - default_binding_prop: true

--- a/client_code/_Components/FileLoader/__init__.py
+++ b/client_code/_Components/FileLoader/__init__.py
@@ -156,7 +156,6 @@ class FileLoader(FileLoaderTemplate):
     font_family = font_family_property('anvil-m3-fileloader-label', 'font')
     icon_size = font_size_property('anvil-m3-fileloader-icon', 'icon_size')
     font_size = font_size_property('anvil-m3-fileloader-label', 'font_size')
-    # align = style_property('anvil-m3-fileloader-form', 'justifyContent', 'align')
     border = style_property('anvil-m3-fileloader-container', 'border', 'border')
     spacing = spacing_property('anvil-m3-fileloader-container')
     tooltip = tooltip_property('anvil-m3-fileloader-container')

--- a/client_code/_Components/FileLoader/__init__.py
+++ b/client_code/_Components/FileLoader/__init__.py
@@ -156,7 +156,7 @@ class FileLoader(FileLoaderTemplate):
     font_family = font_family_property('anvil-m3-fileloader-label', 'font')
     icon_size = font_size_property('anvil-m3-fileloader-icon', 'icon_size')
     font_size = font_size_property('anvil-m3-fileloader-label', 'font_size')
-    align = style_property('anvil-m3-fileloader-form', 'justifyContent', 'align')
+    # align = style_property('anvil-m3-fileloader-form', 'justifyContent', 'align')
     border = style_property('anvil-m3-fileloader-container', 'border', 'border')
     spacing = spacing_property('anvil-m3-fileloader-container')
     tooltip = tooltip_property('anvil-m3-fileloader-container')
@@ -164,6 +164,19 @@ class FileLoader(FileLoaderTemplate):
     show_state = simple_prop("show_state")
     file = simple_prop("file")
     files = simple_prop("files")
+
+
+    @anvil_prop
+    @property
+    def align(self, value) -> str:
+        """The position of this component in the available space."""
+        self.dom_nodes['anvil-m3-fileloader-form'].classList.toggle('anvil-m3-full-width', False)
+        if value == 'full':
+            self.dom_nodes['anvil-m3-fileloader-form'].classList.toggle(
+                'anvil-m3-full-width', True
+            )
+        else:
+            self.dom_nodes['anvil-m3-fileloader-form'].style.justifyContent = value
 
     @anvil_prop
     @property

--- a/client_code/_Components/FileLoader/form_template.yaml
+++ b/client_code/_Components/FileLoader/form_template.yaml
@@ -49,7 +49,7 @@ properties:
   group: Layout
   important: true
   name: align
-  options: [left, center, right]
+  options: [left, center, right, full]
   type: enum
 - {default_value: '', description: The border of this component. Can take any valid CSS border value., group: Look and Feel, important: false, name: border, type: string}
 - {description: The margin and padding (pixels) of the component., group: Layout, important: true, name: spacing, type: spacing}

--- a/theme/assets/anvil-m3/fileloader.css
+++ b/theme/assets/anvil-m3/fileloader.css
@@ -53,7 +53,7 @@
   line-height: 40px;
 } 
 
-.anvil-m3-fileloader-form.anvil-m3-full-width {
+.anvil-m3-fileloader-form.anvil-m3-full-width .anvil-m3-fileloader-container {
     flex-grow: 1;
     display: flex;
     justify-content: center;

--- a/theme/assets/anvil-m3/fileloader.css
+++ b/theme/assets/anvil-m3/fileloader.css
@@ -53,6 +53,14 @@
   line-height: 40px;
 } 
 
+.anvil-m3-fileloader-form.anvil-m3-full-width {
+    flex-grow: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+
 
 /* Elevated */
 .anvil-m3-fileloader-container.anvil-m3-elevated { background-color: var(--anvil-m3-surface-container-low); box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.30); 


### PR DESCRIPTION
The FileLoader mimics the style of Buttons but has no "full" `align` option. This PR fixes that
Closes #266 

![Screenshot 2025-06-05 at 13 47 16](https://github.com/user-attachments/assets/9c2dbf4f-43b2-4c4d-915b-3f0feee2603c)
