### PR TITLE
Adding margin to an AvatarMenu no longer messes with the placement of the menu

### DIFF
--- a/client_code/_Components/AvatarMenu/__init__.py
+++ b/client_code/_Components/AvatarMenu/__init__.py
@@ -20,7 +20,7 @@ class AvatarMenu(MenuMixin, AvatarMenuTemplate):
         self._props = properties
 
         self._menu_node = self.dom_nodes['anvil-m3-avatarMenu-items-container']
-        self._button_node = self.dom_nodes['anvil-m3-avatarMenu-button']
+        self._button_node = self.avatar.dom_nodes['anvil-m3-avatar']
         self._button_node.addEventListener('click', self._handle_click)
 
         MenuMixin.__init__(self, self._button_node, self._menu_node)


### PR DESCRIPTION
Closes #284 

The node to which the menu is attached is now correct. This means, adding bottom margin to the AvatarMenu doesn't push down the menu