### PR TITLE
Fix menu components

### DIFF
--- a/client_code/_Components/MenuMixin.py
+++ b/client_code/_Components/MenuMixin.py
@@ -2,6 +2,7 @@ from anvil.js.window import document
 
 from .._utils import fui, noop
 from .MenuItem import MenuItem
+import anvil.designer
 
 
 class MenuMixin:
@@ -66,8 +67,12 @@ class MenuMixin:
         classes = self._menu_node.classList
         if value is not None:
             classes.toggle('anvil-m3-buttonMenu-items-hidden', not value)
+            if not anvil.designer.in_designer:
+                classes.toggle('anvil-m3-menu-out-designer', not value)
         else:
             classes.toggle('anvil-m3-buttonMenu-items-hidden')
+            if not anvil.designer.in_designer:
+                classes.toggle('anvil-m3-menu-out-designer')
 
         self._open = not classes.contains('anvil-m3-buttonMenu-items-hidden')
         if self._open:

--- a/theme/assets/anvil-m3/menu.css
+++ b/theme/assets/anvil-m3/menu.css
@@ -121,10 +121,13 @@
 .anvil-m3-buttonMenu-items-hidden {
   pointer-events: none;
   opacity: 0;
-  overflow: hidden;
-  display: none;  
+  overflow: hidden;  
 }
 
+.anvil-m3-buttonMenu-items-hidden.anvil-m3-menu-out-designer {
+    display: none;
+}
+  
 /***** DropdownMenu *****/
 .anvil-m3-dropdownMenu-container {
   display: inline-block;

--- a/theme/assets/anvil-m3/menu.css
+++ b/theme/assets/anvil-m3/menu.css
@@ -122,6 +122,7 @@
   pointer-events: none;
   opacity: 0;
   overflow: hidden;
+  display: none;  
 }
 
 /***** DropdownMenu *****/

--- a/theme/assets/anvil-m3/menu.css
+++ b/theme/assets/anvil-m3/menu.css
@@ -105,6 +105,7 @@
 .anvil-m3-buttonMenu-items-container {
   box-sizing: border-box;
   position: absolute;
+  display: block;
   inset: 0 0 auto auto;
   width: max-content;
   min-width: 112px;


### PR DESCRIPTION
Currently, when the Menu part of Menu components is closed, the Menu is set to `opacity: 0` but is still displayed on the page. This PR maintains the current behaviour when the Menu is in the Designer, this keeps the ability to easily drag and drop components into the menu. However, in the running app, the menu is set to `display: none` when closed.

closes #290 