### PR TITLE
FileLoader's default spacing now targets correct element

### DIFF
--- a/client_code/_Components/FileLoader/__init__.py
+++ b/client_code/_Components/FileLoader/__init__.py
@@ -65,7 +65,7 @@ class FileLoader(FileLoaderTemplate):
         ]
 
     def _anvil_get_unset_property_values_(self):
-        el = self.dom_nodes["anvil-m3-fileloader-form"]
+        el = self.dom_nodes["anvil-m3-fileloader-container"]
         sp = get_unset_spacing(el, el, self.spacing)
         tfs = get_unset_value(
             self.dom_nodes['anvil-m3-fileloader-label'], "fontSize", self.font_size

--- a/theme/assets/anvil-m3/fileloader.css
+++ b/theme/assets/anvil-m3/fileloader.css
@@ -11,7 +11,6 @@
 
 .anvil-m3-fileloader-form {
   display: flex;
-  margin: 8px 4px;
 }
 
 .anvil-m3-fileloader-container {
@@ -20,6 +19,7 @@
   color: var(--anvil-m3-primary);
   cursor: pointer;
   text-decoration: none;
+  margin: 8px 4px;
 }
 
 .anvil-m3-fileloader-container .anvil-m3-fileloader-label {


### PR DESCRIPTION
Closes #293

The default margin and padding of the FileLoader now targets the same element that the `spacing` property does.