### PR TITLE
Undo anvil panel rows being centered

### DIFF
--- a/theme/assets/theme.css
+++ b/theme/assets/theme.css
@@ -1023,8 +1023,4 @@ th.month select.monthselect::after {
   border-right: 0;
 }
 
-.anvil-panel-row {
-  align-items:center
-}
-
 .anvil-data-grid .anvil-data-row-col[data-grid-col-id="null"] {padding: 0 !important;}


### PR DESCRIPTION
closes #226 

This PR will mean that M3 components don't automatically line up well because different components have different heights. The way to get around this is to put components in a FlowPanel and set `vertical_align` to `center`.

In future, we might want to create an m3 component that replaces the FlowPanel and functions more like a flexbox