### PR TITLE
Make placeholder text of Filled Buttons more readable

### DIFF
--- a/theme/assets/theme.css
+++ b/theme/assets/theme.css
@@ -636,7 +636,7 @@ body {
 }
 
 .anvil-m3-button.anvil-m3-filled .anvil-m3-textlessComponentText {
-    
+    color: #dfdfdf !important;
 }
 
 .anvil-m3-sidesheet {

--- a/theme/assets/theme.css
+++ b/theme/assets/theme.css
@@ -635,6 +635,10 @@ body {
   font-weight: 400;
 }
 
+.anvil-m3-button.anvil-m3-filled .anvil-m3-textlessComponentText {
+    
+}
+
 .anvil-m3-sidesheet {
   height: 100%;
   width: 300px;


### PR DESCRIPTION
Closes #299

I'm not sure if the contrast is enough in dark color schemes. 
<img width="119" alt="Screenshot 2025-07-07 at 12 44 50" src="https://github.com/user-attachments/assets/8d729ed2-073e-4f7e-9706-b6a92b836b16" />
<img width="119" alt="Screenshot 2025-07-07 at 12 44 13" src="https://github.com/user-attachments/assets/e3a6c50e-232d-4fd7-a8fe-8fe91aef64c4" />
