### PR TITLE
Placeholder text for TextInputs is set to an empty string instead of a space

### DIFF
--- a/client_code/_Components/TextInput/TextArea.py
+++ b/client_code/_Components/TextInput/TextArea.py
@@ -140,7 +140,7 @@ class TextArea(TextInput):
             input.placeholder = value
             input.classList.add('anvil-m3-has-placeholder')
         else:
-            input.placeholder = " "
+            input.placeholder = ""
             input.classList.remove('anvil-m3-has-placeholder')
 
     @anvil_prop

--- a/client_code/_Components/TextInput/TextBox.py
+++ b/client_code/_Components/TextInput/TextBox.py
@@ -209,7 +209,7 @@ class TextBox(TextInput):
             input.placeholder = value
             input.classList.add('anvil-m3-has-placeholder')
         else:
-            input.placeholder = " "
+            input.placeholder = ""
             input.classList.remove('anvil-m3-has-placeholder')
 
     @property


### PR DESCRIPTION
Fixes #88 